### PR TITLE
clean_checkout input to handle cleaning after checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can also use any major tags like `@v1` for any `@v1.*.*`
   | `pyinstaller_ver`     | -        | Specific pyinstaller version you want to use *(with proper signs, like `==5.13.2`)*
   | `exe_path`            | ./dist   | Path on runner-os, where executable will be stored
   | `upload_exe_with_name`| -        | Upload exe_ artifact with this name. Else, it won't upload
+  | `clean_checkout`      | false    | If true, perform a clean checkout; if false, skip cleaning. Cleaning will remove all existing local files not in the repository during checkout. If you use utilities like pyinstaller-versionfile, set this to false.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can also use any major tags like `@v1` for any `@v1.*.*`
   | `pyinstaller_ver`     | -        | Specific pyinstaller version you want to use *(with proper signs, like `==5.13.2`)*
   | `exe_path`            | ./dist   | Path on runner-os, where executable will be stored
   | `upload_exe_with_name`| -        | Upload exe_ artifact with this name. Else, it won't upload
-  | `clean_checkout`      | false    | If true, perform a clean checkout; if false, skip cleaning. Cleaning will remove all existing local files not in the repository during checkout. If you use utilities like pyinstaller-versionfile, set this to false.
+  | `clean_checkout`      | true     | If true, perform a clean checkout; if false, skip cleaning. Cleaning will remove all existing local files not in the repository during checkout. If you use utilities like pyinstaller-versionfile, set this to false.
 
 <br>
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   upload_exe_with_name:
     description: If passed, uploads executable artifact  with this name. Else, artifact won't be uploaded.
     default: ''
+  clean_checkout:
+    description: 'If true, perform a clean checkout; if false, skip cleaning. Cleaning will remove all existing local files not in the repository during checkout. If you use utilities like pyinstaller-versionfile, set this to false.'
+    default: false
 
 outputs:
   executable_path:
@@ -81,7 +84,7 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        clean: false
+        clean: ${{ inputs.clean_checkout }}
     
     - name: (Install) dependencies
       if: inputs.requirements != ''

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,8 @@ runs:
     
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        clean: false
     
     - name: (Install) dependencies
       if: inputs.requirements != ''

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     default: ''
   clean_checkout:
     description: 'If true, perform a clean checkout; if false, skip cleaning. Cleaning will remove all existing local files not in the repository during checkout. If you use utilities like pyinstaller-versionfile, set this to false.'
-    default: false
+    default: true
 
 outputs:
   executable_path:


### PR DESCRIPTION
### `clean_checkout` input
- default: `true`
- If true, perform a clean checkout; if false, skip cleaning. Cleaning will remove all existing local files not in the repository during checkout. If you use utilities like pyinstaller-versionfile, set this to false.

This fixes issue of user wanting to use their own version text file but it is being cleaned by the checkout and very hard to debug.
See https://github.com/aliencaocao/netease_cloudmusic_discord_rpc/issues/4